### PR TITLE
[feat/poll] Add poll functionality

### DIFF
--- a/listeners/__init__.py
+++ b/listeners/__init__.py
@@ -31,4 +31,5 @@ def listen(app):
     app.action("vote")(actions.vote)
 
     # views
-    app.view("poll")(views.poll)
+    app.view("preview_poll")(views.preview_poll)
+    app.view("create_poll")(views.create_poll)

--- a/listeners/__init__.py
+++ b/listeners/__init__.py
@@ -1,5 +1,5 @@
 from . import actions, commands
-from .shortcuts import message_shortcut
+from .shortcuts import global_shortcut, message_shortcut
 
 
 def is_echo(shortcut):
@@ -21,6 +21,7 @@ def listen(app):
     # shortcuts
     app.shortcut("delete_message", [is_echo])(message_shortcut.delete_message)
     app.shortcut("edit_message", [is_echo])(message_shortcut.edit_message)
+    app.shortcut("poll")(global_shortcut.poll)
 
     # actions
     app.action("save_edit")(actions.save_edit)

--- a/listeners/__init__.py
+++ b/listeners/__init__.py
@@ -27,3 +27,4 @@ def listen(app):
     app.action("save_edit")(actions.save_edit)
     app.action("cancel_edit")(actions.cancel_edit)
     app.action("join_meet")(actions.join_meet)
+    app.action("add_option")(actions.add_option)

--- a/listeners/__init__.py
+++ b/listeners/__init__.py
@@ -28,6 +28,7 @@ def listen(app):
     app.action("cancel_edit")(actions.cancel_edit)
     app.action("join_meet")(actions.join_meet)
     app.action("add_option")(actions.add_option)
+    app.action("vote")(actions.vote)
 
     # views
     app.view("poll")(views.poll)

--- a/listeners/__init__.py
+++ b/listeners/__init__.py
@@ -1,4 +1,4 @@
-from . import actions, commands
+from . import actions, commands, views
 from .shortcuts import global_shortcut, message_shortcut
 
 
@@ -28,3 +28,6 @@ def listen(app):
     app.action("cancel_edit")(actions.cancel_edit)
     app.action("join_meet")(actions.join_meet)
     app.action("add_option")(actions.add_option)
+
+    # views
+    app.view("poll")(views.poll)

--- a/listeners/actions.py
+++ b/listeners/actions.py
@@ -231,3 +231,35 @@ def add_option(
         view_id=view_id,
         hash=hash,
     )
+
+
+def vote(
+    body: Dict[str, Any],
+    logger: logging.Logger,
+    action: Dict[str, Any],
+    ack: Ack,
+    respond: Respond,
+):
+    """
+    vote selected option for poll
+    """
+    logger.info(body)
+
+    message, user = get_values(body, ["message", "user"])
+    blocks = message.get("blocks")
+    user_id = user.get("id")
+    block_id = action.get("block_id")
+
+    for block in blocks:
+        if block["block_id"] == block_id:
+            break
+    state_value = block.get("text", {})
+    text = state_value.get("text")
+
+    if user_id in text:
+        state_value.update(text=text.replace(f"<@{user_id}> ", ""))
+    else:
+        state_value.update(text=text + f"<@{user_id}> ")
+
+    ack()
+    respond(blocks=blocks)

--- a/listeners/shortcuts/global_shortcut.py
+++ b/listeners/shortcuts/global_shortcut.py
@@ -60,6 +60,7 @@ def poll(
                 m.button(
                     text=m.plain_text(text=":heavy_plus_sign: 항목 추가"),
                     action_id="add_option",
+                    value="6.4",  # index and value of option_4
                 )
             ],
         ),

--- a/listeners/shortcuts/global_shortcut.py
+++ b/listeners/shortcuts/global_shortcut.py
@@ -73,11 +73,11 @@ def poll(
                 options=[
                     m.option(
                         text=m.mrkdwn(text=":bust_in_silhouette: *익명으로 투표*"),
-                        value="anonymous",
+                        value="1",
                     ),
                     m.option(
                         text=m.mrkdwn(text=":heavy_plus_sign: *항목 추가 허용*"),
-                        value="allow_add_option",
+                        value="2",
                     ),
                 ],
             ),
@@ -101,7 +101,7 @@ def poll(
         trigger_id=body["trigger_id"],
         view=m.View(
             type="modal",
-            callback_id="poll",
+            callback_id="preview_poll",
             title=m.plain_text(text="투표 올리기"),
             submit=m.plain_text(text="미리보기"),
             close=m.plain_text(text="취소"),

--- a/listeners/shortcuts/global_shortcut.py
+++ b/listeners/shortcuts/global_shortcut.py
@@ -1,0 +1,109 @@
+import logging
+from typing import Any, Dict
+
+import slack_sdk
+import utils.models as m
+from slack_bolt import Ack
+
+
+def poll(
+    body: Dict[str, Any],
+    logger: logging.Logger,
+    client: slack_sdk.web.client.WebClient,
+    ack: Ack,
+):
+    """
+    make a poll
+    """
+    logger.info(body)
+
+    ack()
+    blocks = [
+        m.Input(
+            block_id="channel",
+            label=m.plain_text(text=":hash: 채널", emoji=True),
+            element=m.conversations_select(
+                action_id="select",
+                default_to_current_conversation=True,
+                placeholder=m.plain_text(text="채널 선택"),
+                filter=m.filter(
+                    include=["public", "private", "mpim"],
+                    exclude_bot_users=True,
+                ),
+            ),
+        ),
+        m.Divider(),
+        m.Input(
+            block_id="title",
+            label=m.plain_text(text=":ballot_box_with_ballot: 투표 제목", emoji=True),
+            element=m.plain_text_input(action_id="input"),
+        ),
+        m.Input(
+            block_id="option_1",
+            label=m.plain_text(text="항목 1"),
+            element=m.plain_text_input(action_id="input"),
+        ),
+        m.Input(
+            block_id="option_2",
+            label=m.plain_text(text="항목 2"),
+            element=m.plain_text_input(action_id="input"),
+        ),
+        m.Input(
+            block_id="option_3",
+            label=m.plain_text(text="항목 3"),
+            element=m.plain_text_input(action_id="input"),
+            optional=True,
+        ),
+        m.Actions(
+            block_id="add_option",
+            elements=[
+                m.button(
+                    text=m.plain_text(text=":heavy_plus_sign: 항목 추가"),
+                    action_id="add_option",
+                )
+            ],
+        ),
+        m.Divider(),
+        m.Input(
+            block_id="settings",
+            label=m.plain_text(text="설정"),
+            element=m.checkboxes(
+                action_id="checkboxes",
+                options=[
+                    m.option(
+                        text=m.mrkdwn(text=":bust_in_silhouette: *익명으로 투표*"),
+                        value="anonymous",
+                    ),
+                    m.option(
+                        text=m.mrkdwn(text=":heavy_plus_sign: *항목 추가 허용*"),
+                        value="allow_add_option",
+                    ),
+                ],
+            ),
+            optional=True,
+        ),
+        m.Input(
+            block_id="limit",
+            label=m.plain_text(text="1인당 투표 수 제한"),
+            element=m.static_select(
+                action_id="select",
+                initial_option=m.option(text=m.plain_text(text="제한 없음"), value="0"),
+                options=[
+                    m.option(text=m.plain_text(text="제한 없음"), value="0"),
+                    m.option(text=m.plain_text(text="1표"), value="1"),
+                    m.option(text=m.plain_text(text="2표"), value="2"),
+                ],
+            ),
+        ),
+    ]
+    client.views_open(
+        trigger_id=body["trigger_id"],
+        view=m.View(
+            type="modal",
+            callback_id="poll",
+            title=m.plain_text(text="투표 올리기"),
+            submit=m.plain_text(text="미리보기"),
+            close=m.plain_text(text="취소"),
+            blocks=blocks,
+        ),
+    )

--- a/listeners/views.py
+++ b/listeners/views.py
@@ -1,0 +1,64 @@
+import logging
+from typing import Any, Dict
+
+import utils.models as m
+from slack_bolt import Ack, Say
+
+
+def poll(
+    body: Dict[str, Any],
+    logger: logging.Logger,
+    view: Dict[str, Any],
+    ack: Ack,
+    say: Say,
+):
+    """
+    make a poll from the view submission
+    """
+    logger.info(body)
+
+    state_values = view["state"]["values"]
+
+    channel = state_values["channel"]["select"]["selected_conversation"]
+    title = state_values["title"]["input"]["value"]
+    options = [
+        option
+        for block_id, block in state_values.items()
+        if block_id.startswith("option") and (option := block["input"]["value"])
+    ]
+    options = {f"option_{i+1}": option for i, option in enumerate(options)}
+    settings = state_values["settings"]["checkboxes"]["selected_options"]
+    settings = {setting["value"]: True for setting in settings}
+    limit = state_values["limit"]["select"]["selected_option"]["value"]
+
+    metadata = m.metadata(
+        event_type="poll",
+        event_payload={
+            "channel": channel,
+            "title": title,
+            "options": options,
+            "settings": settings,
+            "limit": limit,
+        },
+    )
+
+    blocks = [
+        m.Header(block_id="title", text=m.plain_text(text=title, emoji=True)),
+        m.Divider(),
+        *(
+            m.Section(
+                block_id=block_id,
+                text=m.mrkdwn(text=f"{i+1}. {option}"),
+                accessory=m.button(
+                    action_id="vote",
+                    text=m.plain_text(text=f"{i+1}"),
+                    value=option,
+                ),
+            )
+            for i, (block_id, option) in enumerate(options.items())
+        ),
+        m.Divider(),
+    ]
+
+    ack()
+    say(channel=channel, blocks=blocks, metadata=metadata)

--- a/listeners/views.py
+++ b/listeners/views.py
@@ -48,7 +48,7 @@ def poll(
         *(
             m.Section(
                 block_id=block_id,
-                text=m.mrkdwn(text=f"{i+1}. {option}"),
+                text=m.mrkdwn(text=f"{i+1}. {option}\n"),
                 accessory=m.button(
                     action_id="vote",
                     text=m.plain_text(text=f"{i+1}"),

--- a/listeners/views.py
+++ b/listeners/views.py
@@ -5,15 +5,21 @@ import utils.models as m
 from slack_bolt import Ack, Say
 
 
-def poll(
+def preview_poll(
     body: Dict[str, Any],
     logger: logging.Logger,
     view: Dict[str, Any],
     ack: Ack,
-    say: Say,
 ):
     """
-    make a poll from the view submission
+    preview a poll from the view submission
+
+    settings (int): (0 ~ 3)
+        - anonymous (1): anonymous vote
+        - add_option_allowed (2): add option allowed
+    limit (int):
+        - unlimited (0): no limit
+        - limited (1+): limited
     """
     logger.info(body)
 
@@ -28,37 +34,88 @@ def poll(
     ]
     options = {f"option_{i+1}": option for i, option in enumerate(options)}
     settings = state_values["settings"]["checkboxes"]["selected_options"]
-    settings = {setting["value"]: True for setting in settings}
+    settings = sum(int(setting["value"]) for setting in settings)
     limit = state_values["limit"]["select"]["selected_option"]["value"]
+
+    blocks = [
+        m.Context(elements=[m.mrkdwn(text=f"<#{channel}>")]),
+        m.Section(block_id="title", text=m.mrkdwn(text=title)),
+        m.Divider(),
+        *(
+            m.Section(block_id=block_id, text=m.mrkdwn(text=f"{i+1}. {option}\n"))
+            for i, (block_id, option) in enumerate(options.items())
+        ),
+        m.Divider(),
+        m.Context(
+            elements=[m.mrkdwn(text=f"<@{body['user']['id']}>님이 `/poll`를 실행하였습니다.")]
+        ),
+    ]
+    ack(
+        response_action="push",
+        view=m.View(
+            type="modal",
+            callback_id="create_poll",
+            title=m.plain_text(text="투표 미리보기"),
+            submit=m.plain_text(text="투표 올리기"),
+            close=m.plain_text(text="취소"),
+            blocks=blocks,
+            private_metadata=f"{channel}.{settings}.{limit}",
+        ),
+    )
+
+
+def create_poll(
+    body: Dict[str, Any],
+    logger: logging.Logger,
+    view: Dict[str, Any],
+    ack: Ack,
+    say: Say,
+):
+    """
+    make a poll from the view submission
+    """
+    logger.info(body)
+
+    channel, settings, limit = view["private_metadata"].split(".")
 
     metadata = m.metadata(
         event_type="poll",
         event_payload={
             "channel": channel,
-            "title": title,
-            "options": options,
             "settings": settings,
             "limit": limit,
         },
     )
 
-    blocks = [
-        m.Header(block_id="title", text=m.plain_text(text=title, emoji=True)),
-        m.Divider(),
-        *(
-            m.Section(
-                block_id=block_id,
-                text=m.mrkdwn(text=f"{i+1}. {option}\n"),
-                accessory=m.button(
-                    action_id="vote",
-                    text=m.plain_text(text=f"{i+1}"),
-                    value=option,
-                ),
-            )
-            for i, (block_id, option) in enumerate(options.items())
-        ),
-        m.Divider(),
-    ]
+    overflow = m.overflow(
+        action_id="poll_overflow",
+        options=[
+            m.option(
+                text=m.plain_text(text=":pushpin: 투표 종료", emoji=True),
+                value="end_poll",
+            ),
+            m.option(
+                text=m.plain_text(text=":x: 투표 취소", emoji=True),
+                value="cancel_poll",
+            ),
+        ],
+    ).to_dict()
 
-    ack()
+    blocks = view["blocks"]
+    _, *blocks = blocks
+
+    title = blocks[0]
+    title.update(accessory=overflow)
+
+    options = blocks[2:-2]
+    for i, option in enumerate(options):
+        option.update(
+            accessory=m.button(
+                action_id="vote",
+                text=m.plain_text(text=f"{i+1}"),
+                value=f"{i+1}",
+            ).to_dict(),
+        )
+
+    ack(response_action="clear")
     say(channel=channel, blocks=blocks, metadata=metadata)


### PR DESCRIPTION
**Description:**
This pull request adds the functionality to create and manage polls in the Slack integration. It introduces several new features, including the ability to create polls, add options to existing polls, vote on poll options, and perform actions such as ending or canceling a poll. The changes enhance the interactive experience for users and facilitate better collaboration within Slack channels.

**Changes:**
- Add a new command "/poll" to create a poll with a question and options.
- Implement a global shortcut for creating polls.
- Add actions to add options, vote on options, and perform poll-related actions.
- Create views for previewing and creating polls.
- Modify listeners and commands to handle poll-related actions.
- Update the UI blocks and elements to display poll-related information.
- Add support for poll overflow actions, including ending or canceling a poll.
- Implement necessary logic to update the poll view with new options and vote counts.